### PR TITLE
Update python_version for 3.13

### DIFF
--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Update Python version for 3.13

--- a/wildfire.json
+++ b/wildfire.json
@@ -11,7 +11,7 @@
     "product_name": "WildFire",
     "product_version_regex": ".*",
     "min_phantom_version": "6.3.0",
-    "python_version": "3",
+    "python_version": ["3.9", "3.13"],
     "fips_compliant": true,
     "publisher": "Splunk",
     "consolidate_widgets": true,


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions)