### PR TITLE
fix!: harden WildFire connector handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.40.8
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2016-2025 Splunk Inc.
+   Copyright (c) 2016-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: WildFire
-Copyright (c) 2016-2025 Splunk Inc.
+Copyright (c) 2016-2026 Splunk Inc.

--- a/README.md
+++ b/README.md
@@ -1686,7 +1686,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/display_report.html
+++ b/display_report.html
@@ -11,7 +11,7 @@
 {% block widget_content %}
   <!-- Main Start Block -->
   <!-- File: display_report.html
-  Copyright (c) 2016-2025 Splunk Inc.
+  Copyright (c) 2016-2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -96,7 +96,7 @@ and limitations under the License.
             </td>
             <td>
               <a href="javascript:;"
-                 onclick="context_menu(this, [{'contains': ['sha256', 'hash'], 'value': '{{ result.file_info.sha256 }}' }], 0, {{ container.id }}, null, false);">
+                 onclick="context_menu(this, [{'contains': ['sha256', 'hash'], 'value': '{{ result.file_info.sha256|escapejs }}' }], 0, {{ container.id }}, null, false);">
                 {{ result.file_info.sha256 }}
                 &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
               </a>
@@ -110,7 +110,7 @@ and limitations under the License.
             </td>
             <td>
               <a href="javascript:;"
-                 onclick="context_menu(this, [{'contains': ['md5', 'hash'], 'value': '{{ result.file_info.md5 }}' }], 0, {{ container.id }}, null, false);">
+                 onclick="context_menu(this, [{'contains': ['md5', 'hash'], 'value': '{{ result.file_info.md5|escapejs }}' }], 0, {{ container.id }}, null, false);">
                 {{ result.file_info.md5 }}
                 &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
               </a>
@@ -155,7 +155,7 @@ and limitations under the License.
                 </td>
                 <td>
                   <a href="javascript:;"
-                     onclick="context_menu(this, [{'contains': ['sha256', 'hash'], 'value': '{{ report.sha256 }}' }], 0, {{ container.id }}, null, false);">
+                     onclick="context_menu(this, [{'contains': ['sha256', 'hash'], 'value': '{{ report.sha256|escapejs }}' }], 0, {{ container.id }}, null, false);">
                     {{ report.sha256 }}
                     &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                   </a>
@@ -251,7 +251,7 @@ and limitations under the License.
                     <tr>
                       <td>
                         <a href="javascript:;"
-                           onclick="context_menu(this, [{'contains': ['url'], 'value': '{{ curr_url.url }}' }], 0, {{ container.id }}, null, false);">
+                           onclick="context_menu(this, [{'contains': ['url'], 'value': '{{ curr_url.url|escapejs }}' }], 0, {{ container.id }}, null, false);">
                           {{ curr_url.url }}
                           &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                         </a>
@@ -276,7 +276,7 @@ and limitations under the License.
                     <tr>
                       <td>
                         <a href="javascript:;"
-                           onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ curr_tcp|by_key:'@ip' }}' }], 0, {{ container.id }}, null, false);">
+                           onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ curr_tcp|by_key:'@ip'|escapejs }}' }], 0, {{ container.id }}, null, false);">
                           {{ curr_tcp|by_key:"@ip" }}
                           &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                         </a>
@@ -302,7 +302,7 @@ and limitations under the License.
                     <tr>
                       <td>
                         <a href="javascript:;"
-                           onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ curr_udp|by_key:'@ip' }}' }], 0, {{ container.id }}, null, false);">
+                           onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ curr_udp|by_key:'@ip'|escapejs }}' }], 0, {{ container.id }}, null, false);">
                           {{ curr_udp|by_key:"@ip" }}
                           &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                         </a>
@@ -328,7 +328,7 @@ and limitations under the License.
                     <tr>
                       <td>
                         <a href="javascript:;"
-                           onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ curr_dns|by_key:'@query' }}' }], 0, {{ container.id }}, null, false);">
+                           onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ curr_dns|by_key:'@query'|escapejs }}' }], 0, {{ container.id }}, null, false);">
                           {{ curr_dns|by_key:"@query" }}
                           &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                         </a>
@@ -336,7 +336,7 @@ and limitations under the License.
                       <td>
                         {% if curr_dns|by_key:'@response' %}
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ curr_dns|by_key:'@response' }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ curr_dns|by_key:'@response'|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ curr_dns|by_key:"@response" }}
                             &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                           </a>
@@ -382,14 +382,14 @@ and limitations under the License.
                     <tr>
                       <td>
                         <a href="javascript:;"
-                           onclick="context_menu(this, [{'contains': ['process name'], 'value': '{{ curr_proc|by_key:'@name' }}' }], 0, {{ container.id }}, null, false);">
+                           onclick="context_menu(this, [{'contains': ['process name'], 'value': '{{ curr_proc|by_key:'@name'|escapejs }}' }], 0, {{ container.id }}, null, false);">
                           {{ curr_proc|by_key:'@name' }}
                           &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                         </a>
                       </td>
                       <td>
                         <a href="javascript:;"
-                           onclick="context_menu(this, [{'contains': ['pid'], 'value': '{{ curr_proc|by_key:'@pid' }}' }], 0, {{ container.id }}, null, false);">
+                           onclick="context_menu(this, [{'contains': ['pid'], 'value': '{{ curr_proc|by_key:'@pid'|escapejs }}' }], 0, {{ container.id }}, null, false);">
                           {{ curr_proc|by_key:'@pid' }}
                           &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                         </a>
@@ -421,7 +421,7 @@ and limitations under the License.
                           </td>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['process command'], 'value': '{{ curr_proc|by_key:'@command' }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['process command'], 'value': '{{ curr_proc|by_key:'@command'|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ curr_proc|by_key:'@command' }}
                               &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                             </a>
@@ -491,7 +491,7 @@ and limitations under the License.
                             <tr>
                               <td>
                                 <a href="javascript:;"
-                                   onclick="context_menu(this, [{'contains': ['file path'], 'value': '{{ curr_file|by_key:'@name' }}' }], 0, {{ container.id }}, null, false);">
+                                   onclick="context_menu(this, [{'contains': ['file path'], 'value': '{{ curr_file|by_key:'@name'|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                   {{ curr_file|by_key:'@name' }}
                                   &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                                 </a>
@@ -501,7 +501,7 @@ and limitations under the License.
                               <td>
                                 {% if curr_file|by_key:'@sha256' %}
                                   <a href="javascript:;"
-                                     onclick="context_menu(this, [{'contains': ['sha256', 'hash'], 'value': '{{ curr_file|by_key:'@sha256' }}' }], 0, {{ container.id }}, null, false);">
+                                     onclick="context_menu(this, [{'contains': ['sha256', 'hash'], 'value': '{{ curr_file|by_key:'@sha256'|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                     {{ curr_file|by_key:'@sha256' }}
                                     &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                                   </a>
@@ -510,7 +510,7 @@ and limitations under the License.
                               <td>
                                 {% if curr_file|by_key:'@md5' %}
                                   <a href="javascript:;"
-                                     onclick="context_menu(this, [{'contains': ['md5', 'hash'], 'value': '{{ curr_file|by_key:'@md5' }}' }], 0, {{ container.id }}, null, false);">
+                                     onclick="context_menu(this, [{'contains': ['md5', 'hash'], 'value': '{{ curr_file|by_key:'@md5'|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                     {{ curr_file|by_key:'@md5' }}
                                     &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                                   </a>
@@ -519,7 +519,7 @@ and limitations under the License.
                               <td>
                                 {% if curr_file|by_key:'@sha1' %}
                                   <a href="javascript:;"
-                                     onclick="context_menu(this, [{'contains': ['sha1', 'hash'], 'value': '{{ curr_file|by_key:'@sha1' }}' }], 0, {{ container.id }}, null, false);">
+                                     onclick="context_menu(this, [{'contains': ['sha1', 'hash'], 'value': '{{ curr_file|by_key:'@sha1'|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                     {{ curr_file|by_key:'@sha1' }}
                                     &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                                   </a>
@@ -545,7 +545,7 @@ and limitations under the License.
                             <tr>
                               <td>
                                 <a href="javascript:;"
-                                   onclick="context_menu(this, [{'contains': ['file path'], 'value': '{{ curr_file|by_key:'@name' }}' }], 0, {{ container.id }}, null, false);">
+                                   onclick="context_menu(this, [{'contains': ['file path'], 'value': '{{ curr_file|by_key:'@name'|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                   {{ curr_file|by_key:'@name' }}
                                   &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                                 </a>
@@ -555,7 +555,7 @@ and limitations under the License.
                               <td>
                                 {% if curr_file|by_key:'@sha256' %}
                                   <a href="javascript:;"
-                                     onclick="context_menu(this, [{'contains': ['sha256', 'hash'], 'value': '{{ curr_file|by_key:'@sha256' }}' }], 0, {{ container.id }}, null, false);">
+                                     onclick="context_menu(this, [{'contains': ['sha256', 'hash'], 'value': '{{ curr_file|by_key:'@sha256'|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                     {{ curr_file|by_key:'@sha256' }}
                                     &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                                   </a>
@@ -564,7 +564,7 @@ and limitations under the License.
                               <td>
                                 {% if curr_file|by_key:'@md5' %}
                                   <a href="javascript:;"
-                                     onclick="context_menu(this, [{'contains': ['md5', 'hash'], 'value': '{{ curr_file|by_key:'@md5' }}' }], 0, {{ container.id }}, null, false);">
+                                     onclick="context_menu(this, [{'contains': ['md5', 'hash'], 'value': '{{ curr_file|by_key:'@md5'|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                     {{ curr_file|by_key:'@md5' }}
                                     &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                                   </a>
@@ -573,7 +573,7 @@ and limitations under the License.
                               <td>
                                 {% if curr_file|by_key:'@sha1' %}
                                   <a href="javascript:;"
-                                     onclick="context_menu(this, [{'contains': ['sha1', 'hash'], 'value': '{{ curr_file|by_key:'@sha1' }}' }], 0, {{ container.id }}, null, false);">
+                                     onclick="context_menu(this, [{'contains': ['sha1', 'hash'], 'value': '{{ curr_file|by_key:'@sha1'|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                     {{ curr_file|by_key:'@sha1' }}
                                     &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                                   </a>
@@ -605,28 +605,28 @@ and limitations under the License.
                     <tr>
                       <td>
                         <a href="javascript:;"
-                           onclick="context_menu(this, [{'contains': ['process name'], 'value': '{{ curr_proc|by_key:'@child_process_image' }}' }], 0, {{ container.id }}, null, false);">
+                           onclick="context_menu(this, [{'contains': ['process name'], 'value': '{{ curr_proc|by_key:'@child_process_image'|escapejs }}' }], 0, {{ container.id }}, null, false);">
                           {{ curr_proc|by_key:'@child_process_image' }}
                           &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                         </a>
                       </td>
                       <td>
                         <a href="javascript:;"
-                           onclick="context_menu(this, [{'contains': ['pid'], 'value': '{{ curr_proc|by_key:'@child_pid' }}' }], 0, {{ container.id }}, null, false);">
+                           onclick="context_menu(this, [{'contains': ['pid'], 'value': '{{ curr_proc|by_key:'@child_pid'|escapejs }}' }], 0, {{ container.id }}, null, false);">
                           {{ curr_proc|by_key:'@child_pid' }}
                           &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                         </a>
                       </td>
                       <td>
                         <a href="javascript:;"
-                           onclick="context_menu(this, [{'contains': ['process name'], 'value': '{{ curr_proc|by_key:'@parent_process_image' }}' }], 0, {{ container.id }}, null, false);">
+                           onclick="context_menu(this, [{'contains': ['process name'], 'value': '{{ curr_proc|by_key:'@parent_process_image'|escapejs }}' }], 0, {{ container.id }}, null, false);">
                           {{ curr_proc|by_key:'@parent_process_image' }}
                           &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                         </a>
                       </td>
                       <td>
                         <a href="javascript:;"
-                           onclick="context_menu(this, [{'contains': ['pid'], 'value': '{{ curr_proc|by_key:'@parent_pid' }}' }], 0, {{ container.id }}, null, false);">
+                           onclick="context_menu(this, [{'contains': ['pid'], 'value': '{{ curr_proc|by_key:'@parent_pid'|escapejs }}' }], 0, {{ container.id }}, null, false);">
                           {{ curr_proc|by_key:'@parent_pid' }}
                           &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                         </a>
@@ -649,28 +649,28 @@ and limitations under the License.
                     <tr>
                       <td>
                         <a href="javascript:;"
-                           onclick="context_menu(this, [{'contains': ['process name'], 'value': '{{ curr_proc|by_key:'@child_process_image' }}' }], 0, {{ container.id }}, null, false);">
+                           onclick="context_menu(this, [{'contains': ['process name'], 'value': '{{ curr_proc|by_key:'@child_process_image'|escapejs }}' }], 0, {{ container.id }}, null, false);">
                           {{ curr_proc|by_key:'@child_process_image' }}
                           &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                         </a>
                       </td>
                       <td>
                         <a href="javascript:;"
-                           onclick="context_menu(this, [{'contains': ['pid'], 'value': '{{ curr_proc|by_key:'@child_pid' }}' }], 0, {{ container.id }}, null, false);">
+                           onclick="context_menu(this, [{'contains': ['pid'], 'value': '{{ curr_proc|by_key:'@child_pid'|escapejs }}' }], 0, {{ container.id }}, null, false);">
                           {{ curr_proc|by_key:'@child_pid' }}
                           &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                         </a>
                       </td>
                       <td>
                         <a href="javascript:;"
-                           onclick="context_menu(this, [{'contains': ['process name'], 'value': '{{ curr_proc|by_key:'@parent_process_image' }}' }], 0, {{ container.id }}, null, false);">
+                           onclick="context_menu(this, [{'contains': ['process name'], 'value': '{{ curr_proc|by_key:'@parent_process_image'|escapejs }}' }], 0, {{ container.id }}, null, false);">
                           {{ curr_proc|by_key:'@parent_process_image' }}
                           &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                         </a>
                       </td>
                       <td>
                         <a href="javascript:;"
-                           onclick="context_menu(this, [{'contains': ['pid'], 'value': '{{ curr_proc|by_key:'@parent_pid' }}' }], 0, {{ container.id }}, null, false);">
+                           onclick="context_menu(this, [{'contains': ['pid'], 'value': '{{ curr_proc|by_key:'@parent_pid'|escapejs }}' }], 0, {{ container.id }}, null, false);">
                           {{ curr_proc|by_key:'@parent_pid' }}
                           &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                         </a>
@@ -694,14 +694,14 @@ and limitations under the License.
                       <td>{{ curr_reg|by_key:"@reg_key" }}</td>
                       <td>
                         <a href="javascript:;"
-                           onclick="context_menu(this, [{'contains': ['process name'], 'value': '{{ curr_reg|by_key:'@process_image' }}' }], 0, {{ container.id }}, null, false);">
+                           onclick="context_menu(this, [{'contains': ['process name'], 'value': '{{ curr_reg|by_key:'@process_image'|escapejs }}' }], 0, {{ container.id }}, null, false);">
                           {{ curr_reg|by_key:'@process_image' }}
                           &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                         </a>
                       </td>
                       <td>
                         <a href="javascript:;"
-                           onclick="context_menu(this, [{'contains': ['pid'], 'value': '{{ curr_reg|by_key:'@pid' }}' }], 0, {{ container.id }}, null, false);">
+                           onclick="context_menu(this, [{'contains': ['pid'], 'value': '{{ curr_reg|by_key:'@pid'|escapejs }}' }], 0, {{ container.id }}, null, false);">
                           {{ curr_reg|by_key:'@pid' }}
                           &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                         </a>
@@ -724,14 +724,14 @@ and limitations under the License.
                       <td>{{ curr_reg|by_key:"@reg_key" }}</td>
                       <td>
                         <a href="javascript:;"
-                           onclick="context_menu(this, [{'contains': ['process name'], 'value': '{{ curr_reg|by_key:'@process_image' }}' }], 0, {{ container.id }}, null, false);">
+                           onclick="context_menu(this, [{'contains': ['process name'], 'value': '{{ curr_reg|by_key:'@process_image'|escapejs }}' }], 0, {{ container.id }}, null, false);">
                           {{ curr_reg|by_key:'@process_image' }}
                           &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                         </a>
                       </td>
                       <td>
                         <a href="javascript:;"
-                           onclick="context_menu(this, [{'contains': ['pid'], 'value': '{{ curr_reg|by_key:'@pid' }}' }], 0, {{ container.id }}, null, false);">
+                           onclick="context_menu(this, [{'contains': ['pid'], 'value': '{{ curr_reg|by_key:'@pid'|escapejs }}' }], 0, {{ container.id }}, null, false);">
                           {{ curr_reg|by_key:'@pid' }}
                           &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                         </a>
@@ -754,14 +754,14 @@ and limitations under the License.
                       <td>{{ curr_reg|by_key:"@reg_key" }}</td>
                       <td>
                         <a href="javascript:;"
-                           onclick="context_menu(this, [{'contains': ['process name'], 'value': '{{ curr_reg|by_key:'@process_image' }}' }], 0, {{ container.id }}, null, false);">
+                           onclick="context_menu(this, [{'contains': ['process name'], 'value': '{{ curr_reg|by_key:'@process_image'|escapejs }}' }], 0, {{ container.id }}, null, false);">
                           {{ curr_reg|by_key:'@process_image' }}
                           &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                         </a>
                       </td>
                       <td>
                         <a href="javascript:;"
-                           onclick="context_menu(this, [{'contains': ['pid'], 'value': '{{ curr_reg|by_key:'@pid' }}' }], 0, {{ container.id }}, null, false);">
+                           onclick="context_menu(this, [{'contains': ['pid'], 'value': '{{ curr_reg|by_key:'@pid'|escapejs }}' }], 0, {{ container.id }}, null, false);">
                           {{ curr_reg|by_key:'@pid' }}
                           &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                         </a>
@@ -783,21 +783,21 @@ and limitations under the License.
                     <tr>
                       <td>
                         <a href="javascript:;"
-                           onclick="context_menu(this, [{'contains': ['file path'], 'value': '{{ curr_file|by_key:'@deleted_file' }}' }], 0, {{ container.id }}, null, false);">
+                           onclick="context_menu(this, [{'contains': ['file path'], 'value': '{{ curr_file|by_key:'@deleted_file'|escapejs }}' }], 0, {{ container.id }}, null, false);">
                           {{ curr_file|by_key:'@deleted_file' }}
                           &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                         </a>
                       </td>
                       <td>
                         <a href="javascript:;"
-                           onclick="context_menu(this, [{'contains': ['process name'], 'value': '{{ curr_file|by_key:'@process_image' }}' }], 0, {{ container.id }}, null, false);">
+                           onclick="context_menu(this, [{'contains': ['process name'], 'value': '{{ curr_file|by_key:'@process_image'|escapejs }}' }], 0, {{ container.id }}, null, false);">
                           {{ curr_file|by_key:'@process_image' }}
                           &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                         </a>
                       </td>
                       <td>
                         <a href="javascript:;"
-                           onclick="context_menu(this, [{'contains': ['pid'], 'value': '{{ curr_file|by_key:'@pid' }}' }], 0, {{ container.id }}, null, false);">
+                           onclick="context_menu(this, [{'contains': ['pid'], 'value': '{{ curr_file|by_key:'@pid'|escapejs }}' }], 0, {{ container.id }}, null, false);">
                           {{ curr_file|by_key:'@pid' }}
                           &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                         </a>
@@ -819,21 +819,21 @@ and limitations under the License.
                     <tr>
                       <td>
                         <a href="javascript:;"
-                           onclick="context_menu(this, [{'contains': ['file path'], 'value': '{{ curr_file|by_key:'@written_file' }}' }], 0, {{ container.id }}, null, false);">
+                           onclick="context_menu(this, [{'contains': ['file path'], 'value': '{{ curr_file|by_key:'@written_file'|escapejs }}' }], 0, {{ container.id }}, null, false);">
                           {{ curr_file|by_key:'@written_file' }}
                           &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                         </a>
                       </td>
                       <td>
                         <a href="javascript:;"
-                           onclick="context_menu(this, [{'contains': ['process name'], 'value': '{{ curr_file|by_key:'@process_image' }}' }], 0, {{ container.id }}, null, false);">
+                           onclick="context_menu(this, [{'contains': ['process name'], 'value': '{{ curr_file|by_key:'@process_image'|escapejs }}' }], 0, {{ container.id }}, null, false);">
                           {{ curr_file|by_key:'@process_image' }}
                           &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                         </a>
                       </td>
                       <td>
                         <a href="javascript:;"
-                           onclick="context_menu(this, [{'contains': ['pid'], 'value': '{{ curr_file|by_key:'@pid' }}' }], 0, {{ container.id }}, null, false);">
+                           onclick="context_menu(this, [{'contains': ['pid'], 'value': '{{ curr_file|by_key:'@pid'|escapejs }}' }], 0, {{ container.id }}, null, false);">
                           {{ curr_file|by_key:'@pid' }}
                           &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                         </a>

--- a/json_dump.html
+++ b/json_dump.html
@@ -10,7 +10,7 @@
 {% block custom_tools %}{% endblock %}
 {% block widget_content %}
   <!-- File: json_dump.html
-  Copyright (c) 2016-2025 Splunk Inc.
+  Copyright (c) 2016-2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Verify WildFire server certificates by default.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * Verify WildFire server certificates by default.
+* Escape dynamic-analysis values in the detonation report context menu.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,4 @@
 
 * Verify WildFire server certificates by default.
 * Escape dynamic-analysis values in the detonation report context menu.
+* Keep downloaded WildFire files inside connector-controlled vault staging paths.

--- a/wildfire.json
+++ b/wildfire.json
@@ -30,7 +30,7 @@
             "data_type": "boolean",
             "description": "Verify server certificate",
             "order": 1,
-            "default": false
+            "default": true
         },
         "api_key": {
             "data_type": "password",

--- a/wildfire.json
+++ b/wildfire.json
@@ -17,7 +17,7 @@
     "consolidate_widgets": true,
     "logo": "logo_paloaltonetworks.svg",
     "logo_dark": "logo_paloaltonetworks_dark.svg",
-    "license": "Copyright (c) 2016-2025 Splunk Inc.",
+    "license": "Copyright (c) 2016-2026 Splunk Inc.",
     "configuration": {
         "base_url": {
             "data_type": "string",

--- a/wildfire_connector.py
+++ b/wildfire_connector.py
@@ -1,6 +1,6 @@
 # File: wildfire_connector.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -380,7 +380,7 @@ class WildfireConnector(BaseConnector):
             filename = vault_id
 
         try:
-            success, message, vault_info = ph_rules.vault_info(vault_id=vault_id, container_id=self.get_container_id(), trace=False)
+            _success, _message, vault_info = ph_rules.vault_info(vault_id=vault_id, container_id=self.get_container_id(), trace=False)
             vault_info = next(iter(vault_info))
         except IndexError:
             return action_result.set_status(phantom.APP_ERROR, "Vault file could not be found with supplied Vault ID"), None
@@ -424,7 +424,7 @@ class WildfireConnector(BaseConnector):
 
         files = {"file": (filename, payload)}
 
-        ret_val, response = self._make_rest_call("/submit/file", self, self.FILE_UPLOAD_ERROR_DESC, method="post", files=files)
+        ret_val, _response = self._make_rest_call("/submit/file", self, self.FILE_UPLOAD_ERROR_DESC, method="post", files=files)
 
         if phantom.is_fail(ret_val):
             self.append_to_message("Test Connectivity Failed")
@@ -591,7 +591,7 @@ class WildfireConnector(BaseConnector):
             error_message = self._get_error_message_from_exception(e)
             return action_result.set_status(phantom.APP_ERROR, "Unable to create temporary folder '/vault/tmp'.", error_message)
 
-        file_path = f"{local_dir}/{sample_hash}"
+        file_path = os.path.join(local_dir, uuid.uuid4().hex)
 
         # open and download the file
         try:
@@ -912,7 +912,7 @@ class WildfireConnector(BaseConnector):
         metadata = None
 
         try:
-            success, message, vault_meta_info = ph_rules.vault_info(container_id=self.get_container_id(), vault_id=vault_id, trace=False)
+            _success, message, vault_meta_info = ph_rules.vault_info(container_id=self.get_container_id(), vault_id=vault_id, trace=False)
             if not vault_meta_info:
                 self.debug_print(f"Error while fetching meta information for vault ID: {vault_id}, message: {message}")
                 return action_result.set_status(phantom.APP_ERROR, WILDFIRE_ERR_FILE_NOT_FOUND_IN_VAULT), None

--- a/wildfire_consts.py
+++ b/wildfire_consts.py
@@ -1,6 +1,6 @@
 # File: wildfire_consts.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/wildfire_view.py
+++ b/wildfire_view.py
@@ -1,6 +1,6 @@
 # File: wildfire_view.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Bug Fixes

- PSAAS-30784: new WildFire assets now verify server certificates by default.
- PSAAS-31091: escape dynamic-analysis values embedded in detonation-report context-menu JavaScript strings.
- PSAAS-31416: use a connector-generated temporary filename for downloaded content before adding it to the vault.

### Manual Documentation

- [x] No `manual_readme_content.md` change is needed; the existing asset setting default changes and report/download protections need no manual setup.

### Other information

- The TLS default is a breaking secure-default change; existing assets can retain an explicit opt-out where required.
- The report rendering fix uses Django `escapejs` on every value interpolated into a single-quoted inline JavaScript string.
- The vault staging fix preserves the requested identifier as vault metadata but never uses it as a filesystem path component.
- Tracking: PAPP-38104; PSAAS-30784 (VULN-93509 / FS-1594), PSAAS-31091 (VULN-93816 / FS-1932), and PSAAS-31416 (VULN-94141 / FS-2298).
- Validated locally with the refreshed Python 3.13 hook configuration, `python3 -m py_compile`, JSON parsing, structural sink/path checks, and `git diff --check`.

Written by Codex.